### PR TITLE
Replace shell functions with built in make functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ thesis.pdf: $(SRCS)
 	pdflatex $(LATEX_FLAGS) thesis
 
 clean:
-	-rm \
-		thesis-gnuplottex* \
-		thesis.{gnuploterrors,aux,bbl,bcf,blg,lof,log,lol,lot,out,pdf,run.xml,toc}
+	-@$(RM) \
+			$(wildcard thesis-gnuplottex*) \
+			$(addprefix thesis,.gnuploterrors .aux .bbl .bcf .blg .lof .log .lol .lot .out .pdf .run.xml .toc)
 .PHONY: clean


### PR DESCRIPTION
Improves cross shell compatibility, and prevents `make clean` from failing when files are not found.
Also suppressed make clean output.
