### PR TITLE
GH 21

### DIFF
--- a/ntnuthesis.cls
+++ b/ntnuthesis.cls
@@ -303,3 +303,12 @@
     filecolor=black,    % file links
     urlcolor=black      % external links
 }
+
+% Renew \lstlistoflistings command to avoid issues with incorrect headers for long lists
+% Uses unnumbered chapter instead of a float like in the original source code.
+% Based on source code for listings package https://ctan.uib.no/macros/latex/contrib/listings/listings.dtx line: 14635
+\renewcommand*{\lstlistoflistings}{%
+       \chapter*{\lstlistlistingname}%
+       \parskip\z@\parindent\z@\parfillskip \z@ \@plus 1fil%
+       \@starttoc{lol}%
+       }%

--- a/thesis.tex
+++ b/thesis.tex
@@ -28,7 +28,8 @@
 \input{chapters/3-structure.tex}
 \input{chapters/4-conclusion.tex}
 
-\printbibliography
+\chapter*{\bibname}
+\printbibliography[heading=none]
 
 \input{chapters/papers.tex}
 


### PR DESCRIPTION
Addresses issue #21

The \printbibliography command seems to create its own "environment" when printing that ends as soon as the contents are printed. After this, the preceeding chapter will "take over". This creates issues with headers if the bibliography ends on an odd numbered page, other than the first page of the bibliography. This issue is avoided by printing the bibliography without a heading, and creating a chapter instead.

The issue with the code listings was addressed by changing the behaviour of the \lstlistoflistings command to create an unnumbered chapter, instead of a float like the original source code in the package does.