### PR TITLE
Add spacing between chapters in list of listings

### DIFF
--- a/ntnuthesis.cls
+++ b/ntnuthesis.cls
@@ -147,6 +147,7 @@
 \RequirePackage[scaled=.88]{berasans}       % sans serif font
 \RequirePackage[scaled=.82]{DejaVuSansMono} % monospace font (for code)
 \RequirePackage{listings}                   % code listings
+\RequirePackage{etoolbox}                   % fixing list of listings spacing
 \RequirePackage{babel}                      % language specifics
 \RequirePackage{geometry}                   % page layout
 \RequirePackage{enumitem}                   % customising list appearance
@@ -294,6 +295,9 @@
         {€}{{\euro}}1 {£}{{\pounds}}1 {«}{{\guillemotleft}}1
         {»}{{\guillemotright}}1 {ñ}{{\~n}}1 {Ñ}{{\~N}}1 {¿}{{?`}}1
 }
+
+% Ensure list of listings have additional spacing between chapters to match figures and tables
+\pretocmd{\chapter}{\addtocontents{lol}{\protect\addvspace{10\p@}}}{}{}
 
 % Settings for hyperref: setting all the links black for best printing. They will still be clickable in the PDF
 \hypersetup{


### PR DESCRIPTION
When the thesis contains figures and tables in several different chapters, the `report` class adds a space between entries from each chapter in the list of figures and list of tables. This behavior is not standard for the list of listings. This patch fixes that issue by patching `\@chapter` to add a space between chapters in `thesis.lol`, such that the spacing is consistent across all of the lists, and improves readability.

Before:

![image](https://user-images.githubusercontent.com/6617815/115727683-206da800-a384-11eb-9af8-0e4f03746e7c.png)

After:

![image](https://user-images.githubusercontent.com/6617815/115727708-26638900-a384-11eb-8d63-48563c11a733.png)
