### PR TITLE
Adds enforcing of image dpi within document

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,5 +1,8 @@
 \documentclass[british,titlepage]{ntnuthesis}
 
+
+\pdfimageresolution=150 % enforces 150 DPI for images scaled at 1
+
 \title{An NTNU Thesis \LaTeX{} Document Class}
 \shorttitle{An NTNU Thesis Document Class}
 \author{Community of Practice in Computer Science Education at NTNU}


### PR DESCRIPTION
This PR adds enforcing of the DPI of images within the document to 150, which is the minimum to pass the validation of "grafisk senter". I chose to put the command in the main preamble, so that the user could choose to increase this if wanted. 

This option greatly simplified our process of validation, so I thought it would be worthwhile to send a PR.
