### PR TITLE
Use Letters instead of Roman numerals for Papers

### DIFF
--- a/ntnuthesis.cls
+++ b/ntnuthesis.cls
@@ -224,7 +224,7 @@
 % Support for included papers (for compiled PhD theses)
 \newcounter{paper}
 \setcounter{paper}{0}
-\def\thepaper{\Roman{paper}}
+\def\thepaper{\Alph{paper}}
 \newenvironment{paper}[2]
 {
     \refstepcounter{paper}


### PR DESCRIPTION
It seems the norm on (at least) the Faculty of Information Technology and Electrical Engineering (IE) is to enumerate Papers using letters instead of Roman numerals. Take with a grain of salt: Based on a small set of samples (PhD theses) from my personal experience.