### PR TITLE
Fix chapter name in headings for long glossary and acronym lists

### DIFF
--- a/ntnuthesis.cls
+++ b/ntnuthesis.cls
@@ -322,3 +322,7 @@
        \@starttoc{lol}%
        \endgroup%
        }%
+
+% Renew \glossarysection command to avoid creating a section for the glossary.
+% Using unnumbered chapters for correct chapter name in headings.
+\renewcommand{\glossarysection}[2][]{}

--- a/thesis.tex
+++ b/thesis.tex
@@ -20,7 +20,10 @@
 \listoftables
 \lstlistoflistings
 
+\chapter*{\acronymname}           % Create an unnumbered chapter for the acronyms
 \printglossary[type=\acronymtype] % Print acronyms
+
+\chapter*{\glossaryname}          % Create an unnumbered chapter for the glossary
 \printglossary                    % Print glossary
 
 \input{chapters/1-introduction}


### PR DESCRIPTION
This PR resolves #44.

The \glossarysection command is renewed to do nothing, and explicit unnumbered chapters are added for the glossary and acronyms list. This resolves an issue where the heading for acronym lists or glossaries that exceeds 2 pages is shown as "Tables".